### PR TITLE
Fix buffer index error

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,13 +12,11 @@ function MessageBuffer(messageCount) {
 }
 
 MessageBuffer.prototype.add = function(message) {
-  var idx = this.messagesAdded % this.messageMax;
-  if (this.messagesAdded++ < this.messageMax) {
-    this.buffer.push(message);
-  } else {
-    this.buffer[idx] = message;
+  if (this.messagesAdded++ >= this.messageMax) {
+    this.buffer.shift()
     this.messagesDropped++;
   }
+  this.buffer.push(message);
 }
 
 MessageBuffer.prototype.length = function() {
@@ -33,14 +31,8 @@ MessageBuffer.prototype.drain = function(cb) {
   var oldBuffer = this.buffer;
   this.buffer = [];
 
-  if (this.messagesAdded > oldBuffer.length) {
-    var startIdx = this.messagesAdded % oldBuffer.length;
-    for (var i=startIdx; i<(oldBuffer.length + startIdx); i++) {
-      cb(oldBuffer[i % this.messageMax]);
-    }
-  } else {
-    oldBuffer.forEach(cb);
-  }
+  oldBuffer.forEach(cb)
+
   this.messagesDropped = 0;
   delete old_buffer;
 }

--- a/index.js
+++ b/index.js
@@ -31,8 +31,9 @@ MessageBuffer.prototype.drain = function(cb) {
   var oldBuffer = this.buffer;
   this.buffer = [];
 
-  oldBuffer.forEach(cb)
+  oldBuffer.forEach(cb);
 
+  this.messagesAdded = 0;
   this.messagesDropped = 0;
   delete old_buffer;
 }

--- a/index.js
+++ b/index.js
@@ -136,3 +136,4 @@ function createBunyanStream(args) {
 }
 
 module.exports.createBunyanStream = createBunyanStream;
+module.exports.MessageBuffer = MessageBuffer;

--- a/test/test.js
+++ b/test/test.js
@@ -270,7 +270,7 @@ describe("Disconnect", function() {
 
       }).finally(function() {server.close();});
     });
-  })
+  });
 });
 
 describe("Transforms", function() {
@@ -298,4 +298,33 @@ describe("Transforms", function() {
       }).finally(function() {server.close();});
     });
   });
-})
+});
+
+describe("MessageBuffer", function() {
+  it("should drain all of the messages up to the buffer size", function() {
+    var messageBuffer = new bunyanTcp.MessageBuffer(5);
+
+    messageBuffer.add(1)
+    messageBuffer.add(2)
+    messageBuffer.add(3)
+    messageBuffer.add(4)
+    messageBuffer.add(5)
+
+    var values = []
+
+    messageBuffer.drain(function (value) {
+      values.push(value);
+    });
+
+    messageBuffer.add(6)
+    messageBuffer.add(7)
+    messageBuffer.add(8)
+    messageBuffer.add(9)
+
+    messageBuffer.drain(function (value) {
+      values.push(value);
+    });
+
+    expect(values).to.deep.equal([ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -303,19 +303,19 @@ describe("Transforms", function() {
 describe("MessageBuffer", function() {
   it("should drain all of the messages up to the buffer size", function() {
     var messageBuffer = new bunyanTcp.MessageBuffer(5);
+    var values = []
 
+    messageBuffer.add(0)
     messageBuffer.add(1)
     messageBuffer.add(2)
     messageBuffer.add(3)
     messageBuffer.add(4)
-    messageBuffer.add(5)
-
-    var values = []
 
     messageBuffer.drain(function (value) {
       values.push(value);
     });
 
+    messageBuffer.add(5)
     messageBuffer.add(6)
     messageBuffer.add(7)
     messageBuffer.add(8)
@@ -325,6 +325,6 @@ describe("MessageBuffer", function() {
       values.push(value);
     });
 
-    expect(values).to.deep.equal([ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
+    expect(values).to.deep.equal([ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -305,17 +305,18 @@ describe("MessageBuffer", function() {
     var messageBuffer = new bunyanTcp.MessageBuffer(5);
     var values = []
 
-    messageBuffer.add(0)
+    // use the whole buffer
     messageBuffer.add(1)
     messageBuffer.add(2)
     messageBuffer.add(3)
     messageBuffer.add(4)
+    messageBuffer.add(5)
 
     messageBuffer.drain(function (value) {
       values.push(value);
     });
 
-    messageBuffer.add(5)
+    // don't use the whole buffer
     messageBuffer.add(6)
     messageBuffer.add(7)
     messageBuffer.add(8)
@@ -325,6 +326,6 @@ describe("MessageBuffer", function() {
       values.push(value);
     });
 
-    expect(values).to.deep.equal([ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
+    expect(values).to.deep.equal([ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
   });
 });


### PR DESCRIPTION
resolves #4 

The index for `oldBuffer` isn't guaranteed to be valid/correct. Rather than figure out why, just skip all that math and use some `Array` methods.

Also add a test to expose the issue.